### PR TITLE
[Chore] Update dependencies to latest and fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,18 @@ Metrics/PerceivedComplexity:
 
 Metrics/BlockLength:
   Enabled: false
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    cash-addr (0.2.0)
-      base58 (~> 0.2.2)
+    cash-addr (0.3.0)
+      base58 (~> 0.2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -10,44 +10,46 @@ GEM
     ast (2.4.0)
     base58 (0.2.3)
     diff-lcs (1.3)
-    parallel (1.12.1)
-    parser (2.5.1.0)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
     rainbow (3.0.0)
-    rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rake (13.0.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    rubocop (0.52.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    rubocop (0.81.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
-      powerpack (~> 0.1)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    unicode-display_width (1.3.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.1.4)
   cash-addr!
-  rake (~> 10.0)
-  rspec (~> 3.0)
-  rubocop (~> 0.52.1)
+  rake (~> 13.0.1)
+  rspec (~> 3.9.0)
+  rubocop (~> 0.81.0)
 
 BUNDLED WITH
-   1.16.0
+   2.1.4

--- a/cash-addr.gemspec
+++ b/cash-addr.gemspec
@@ -1,7 +1,6 @@
-
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cash_addr/version'
 
@@ -22,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.52.1'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
+  spec.add_development_dependency 'rake', '~> 13.0.1'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
+  spec.add_development_dependency 'rubocop', '~> 0.81.0'
 
-  spec.add_dependency 'base58', '~> 0.2.2'
+  spec.add_dependency 'base58', '~> 0.2.3'
 end

--- a/lib/cash_addr/address.rb
+++ b/lib/cash_addr/address.rb
@@ -28,7 +28,7 @@ module CashAddr
       @payload = payload
       @digest = digest
 
-      @prefix = prefix ? prefix : DEFAULT_PREFIX
+      @prefix = prefix || DEFAULT_PREFIX
 
       @version = 'P2SHTestnet' if prefix == 'bchtest' && version == 'P2SH'
       @version = 'P2PKHTestnet' if prefix == 'bchtest' && version == 'P2PKH'
@@ -65,6 +65,7 @@ module CashAddr
     def self.from_string(address_string)
       raise(CashAddr::InvalidAddress, 'Expected string as input') unless address_string.is_a?(String)
       return legacy_string(address_string) unless address_string.include?(':')
+
       cash_string(address_string)
     end
 

--- a/lib/cash_addr/version.rb
+++ b/lib/cash_addr/version.rb
@@ -3,5 +3,5 @@
 module CashAddr
   ##
   # Version of the cash-addr gem.
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
Updates dependencies to latest versions to fix a few minor CVE warnings. Also bumped rubocop and linted the codebase with the latest ruleset.